### PR TITLE
Added option to scale images during decoding

### DIFF
--- a/WebPImageSerialization/WebPImageSerialization.h
+++ b/WebPImageSerialization/WebPImageSerialization.h
@@ -40,6 +40,11 @@ extern __attribute__((overloadable)) UIImage * _Nullable UIImageWithWebPData(NSD
  */
 extern __attribute__((overloadable)) UIImage * _Nullable UIImageWithWebPData(NSData *data, CGFloat scale, NSError * __autoreleasing *error);
 
+/**
+ 
+ */
+extern __attribute__((overloadable)) UIImage * _Nullable UIImageWithWebPData(NSData *data, CGFloat scale, CGSize fittingSize, NSError * __autoreleasing *error);
+
 /// Encoding WebP Image Data
 
 /**
@@ -84,6 +89,14 @@ extern __attribute__((overloadable)) NSData * _Nullable UIImageWebPRepresentatio
  */
 + (UIImage * _Nullable)imageWithData:(NSData *)data
                                scale:(CGFloat)scale
+                               error:(NSError * __autoreleasing *)error;
+
+/**
+
+ */
++ (UIImage * _Nullable)imageWithData:(NSData *)data
+                               scale:(CGFloat)scale
+                         fittingSize:(CGSize)fittingSize
                                error:(NSError * __autoreleasing *)error;
 
 /// Creating WebPImage Data


### PR DESCRIPTION
Hi @mattt! One last one from me for now. :)

My app has a use case where I need to generate a small thumbnail copy of the image before I actually need to decode the full size one into memory. Since the WebP framework offers the ability to decode to smaller scales on the fly, I've extended the functions here slightly to expose a `fittingSize` property that will aspect fit the image to the `CGSize` value specified.

Let me know what you think. Thanks!

-Tim