### PR TITLE
fix UIImageWebPRepresentation call

### DIFF
--- a/WebPImageSerialization/WebPImageSerialization.m
+++ b/WebPImageSerialization/WebPImageSerialization.m
@@ -160,7 +160,7 @@ __attribute__((overloadable)) UIImage * _Nullable UIImageWithWebPData(NSData *da
 }
 
 extern __attribute__((overloadable)) NSData * _Nullable UIImageWebPRepresentation(UIImage *image) {
-    return UIImageWebPRepresentation(image, 75.0f, (WebPImagePreset)WebPImageDefaultPreset, nil);
+    return UIImageWebPRepresentation(image, (WebPImagePreset)WebPImageDefaultPreset, 75.0, nil);
 }
 
 __attribute__((overloadable)) NSData * _Nullable UIImageWebPRepresentation(UIImage *image, WebPImagePreset preset, CGFloat quality, NSError * __autoreleasing *error) {


### PR DESCRIPTION
The default/parameterless call swaps the `preset` and `quality` parameters.
Also, changed `75.0f` to `75.0` as CGFloat is double on 64-bit platforms.